### PR TITLE
Reflexer connector

### DIFF
--- a/contracts/connectors/reflexer/events.sol
+++ b/contracts/connectors/reflexer/events.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.7.0;
+
+contract Events {
+    event LogOpen(uint256 indexed vault, bytes32 indexed ilk);
+    event LogClose(uint256 indexed vault, bytes32 indexed ilk);
+    event LogTransfer(uint256 indexed vault, bytes32 indexed ilk, address newOwner);
+    event LogDeposit(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogWithdraw(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogBorrow(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogPayback(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogWithdrawLiquidated(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogExitDai(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogDepositDai(uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogWithdrawDai(uint256 tokenAmt, uint256 getId, uint256 setId);
+
+    event LogDepositAndBorrow(
+        uint256 indexed vault,
+        bytes32 indexed ilk,
+        uint256 depositAmt,
+        uint256 borrowAmt,
+        uint256 getIdDeposit,
+        uint256 getIdBorrow,
+        uint256 setIdDeposit,
+        uint256 setIdBorrow
+    );
+}

--- a/contracts/connectors/reflexer/events.sol
+++ b/contracts/connectors/reflexer/events.sol
@@ -10,8 +10,8 @@ contract Events {
     event LogPayback(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
     event LogWithdrawLiquidated(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
     event LogExit(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
-    event LogDeposit(uint256 tokenAmt, uint256 getId, uint256 setId);
-    event LogWithdraw(uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogDepositCoin(uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogWithdrawCoin(uint256 tokenAmt, uint256 getId, uint256 setId);
 
     event LogDepositAndBorrow(
         uint256 indexed safe,

--- a/contracts/connectors/reflexer/events.sol
+++ b/contracts/connectors/reflexer/events.sol
@@ -10,9 +10,6 @@ contract Events {
     event LogPayback(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
     event LogWithdrawLiquidated(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
     event LogExit(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
-    event LogDepositCoin(uint256 tokenAmt, uint256 getId, uint256 setId);
-    event LogWithdrawCoin(uint256 tokenAmt, uint256 getId, uint256 setId);
-
     event LogDepositAndBorrow(
         uint256 indexed safe,
         bytes32 indexed collateralType,

--- a/contracts/connectors/reflexer/events.sol
+++ b/contracts/connectors/reflexer/events.sol
@@ -1,21 +1,21 @@
 pragma solidity ^0.7.0;
 
 contract Events {
-    event LogOpen(uint256 indexed vault, bytes32 indexed ilk);
-    event LogClose(uint256 indexed vault, bytes32 indexed ilk);
-    event LogTransfer(uint256 indexed vault, bytes32 indexed ilk, address newOwner);
-    event LogDeposit(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
-    event LogWithdraw(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
-    event LogBorrow(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
-    event LogPayback(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
-    event LogWithdrawLiquidated(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
-    event LogExitDai(uint256 indexed vault, bytes32 indexed ilk, uint256 tokenAmt, uint256 getId, uint256 setId);
-    event LogDepositDai(uint256 tokenAmt, uint256 getId, uint256 setId);
-    event LogWithdrawDai(uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogOpen(uint256 indexed safe, bytes32 indexed collateralType);
+    event LogClose(uint256 indexed safe, bytes32 indexed collateralType);
+    event LogTransfer(uint256 indexed safe, bytes32 indexed collateralType, address newOwner);
+    event LogDeposit(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogWithdraw(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogBorrow(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogPayback(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogWithdrawLiquidated(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogExit(uint256 indexed safe, bytes32 indexed collateralType, uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogDeposit(uint256 tokenAmt, uint256 getId, uint256 setId);
+    event LogWithdraw(uint256 tokenAmt, uint256 getId, uint256 setId);
 
     event LogDepositAndBorrow(
-        uint256 indexed vault,
-        bytes32 indexed ilk,
+        uint256 indexed safe,
+        bytes32 indexed collateralType,
         uint256 depositAmt,
         uint256 borrowAmt,
         uint256 getIdDeposit,

--- a/contracts/connectors/reflexer/helpers.sol
+++ b/contracts/connectors/reflexer/helpers.sol
@@ -1,0 +1,124 @@
+pragma solidity ^0.7.0;
+
+import { DSMath } from "../../common/math.sol";
+import { Basic } from "../../common/basic.sol";
+import { TokenInterface } from "../../common/interfaces.sol";
+import { ManagerLike, DaiJoinInterface, PotLike, VatLike, JugLike } from "./interface.sol";
+
+abstract contract Helpers is DSMath, Basic {
+    /**
+     * @dev Manager Interface
+     */
+    ManagerLike internal constant managerContract = ManagerLike(0x5ef30b9986345249bc32d8928B7ee64DE9435E39);
+
+    /**
+     * @dev DAI Join
+     */
+    DaiJoinInterface internal constant daiJoinContract = DaiJoinInterface(0x9759A6Ac90977b93B58547b4A71c78317f391A28);
+
+    /**
+     * @dev Pot
+     */
+    PotLike internal constant potContract = PotLike(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
+
+    /**
+     * @dev Maker MCD Jug Address.
+    */
+    JugLike internal constant mcdJug = JugLike(0x19c0976f590D67707E62397C87829d896Dc0f1F1);
+
+    /**
+     * @dev Return Close Vault Address.
+    */
+    address internal constant giveAddr = 0x4dD58550eb15190a5B3DfAE28BB14EeC181fC267;
+
+    /**
+     * @dev Get Vault's ilk.
+    */
+    function getVaultData(uint vault) internal view returns (bytes32 ilk, address urn) {
+        ilk = managerContract.ilks(vault);
+        urn = managerContract.urns(vault);
+    }
+
+    /**
+     * @dev Gem Join address is ETH type collateral.
+    */
+    function isEth(address tknAddr) internal pure returns (bool) {
+        return tknAddr == ethAddr ? true : false;
+    }
+
+    /**
+     * @dev Get Vault Debt Amount.
+    */
+    function _getVaultDebt(
+        address vat,
+        bytes32 ilk,
+        address urn
+    ) internal view returns (uint wad) {
+        (, uint rate,,,) = VatLike(vat).ilks(ilk);
+        (, uint art) = VatLike(vat).urns(ilk, urn);
+        uint dai = VatLike(vat).dai(urn);
+
+        uint rad = sub(mul(art, rate), dai);
+        wad = rad / RAY;
+
+        wad = mul(wad, RAY) < rad ? wad + 1 : wad;
+    }
+
+    /**
+     * @dev Get Borrow Amount.
+    */
+    function _getBorrowAmt(
+        address vat,
+        address urn,
+        bytes32 ilk,
+        uint amt
+    ) internal returns (int dart)
+    {
+        uint rate = mcdJug.drip(ilk);
+        uint dai = VatLike(vat).dai(urn);
+        if (dai < mul(amt, RAY)) {
+            dart = toInt(sub(mul(amt, RAY), dai) / rate);
+            dart = mul(uint(dart), rate) < mul(amt, RAY) ? dart + 1 : dart;
+        }
+    }
+
+    /**
+     * @dev Get Payback Amount.
+    */
+    function _getWipeAmt(
+        address vat,
+        uint amt,
+        address urn,
+        bytes32 ilk
+    ) internal view returns (int dart)
+    {
+        (, uint rate,,,) = VatLike(vat).ilks(ilk);
+        (, uint art) = VatLike(vat).urns(ilk, urn);
+        dart = toInt(amt / rate);
+        dart = uint(dart) <= art ? - dart : - toInt(art);
+    }
+
+    /**
+     * @dev Convert String to bytes32.
+    */
+    function stringToBytes32(string memory str) internal pure returns (bytes32 result) {
+        require(bytes(str).length != 0, "string-empty");
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            result := mload(add(str, 32))
+        }
+    }
+
+    /**
+     * @dev Get vault ID. If `vault` is 0, get last opened vault.
+    */
+    function getVault(uint vault) internal view returns (uint _vault) {
+        if (vault == 0) {
+            require(managerContract.count(address(this)) > 0, "no-vault-opened");
+            _vault = managerContract.last(address(this));
+        } else {
+            _vault = vault;
+        }
+    }
+
+}

--- a/contracts/connectors/reflexer/helpers.sol
+++ b/contracts/connectors/reflexer/helpers.sol
@@ -70,7 +70,7 @@ abstract contract Helpers is DSMath, Basic {
     ) internal view returns (uint wad) {
         (, uint rate,,,) = SafeEngineLike(safeEngine).collateralTypes(collateralType);
         (, uint debt) = SafeEngineLike(safeEngine).safes(collateralType, handler);
-        uint coin = SafeEngineLike(safeEngine).coin(handler);
+        uint coin = SafeEngineLike(safeEngine).coinBalance(handler);
 
         uint rad = sub(mul(debt, rate), coin);
         wad = rad / RAY;
@@ -89,7 +89,7 @@ abstract contract Helpers is DSMath, Basic {
     ) internal returns (int deltaDebt)
     {
         uint rate = taxCollectorContract.taxSingle(collateralType);
-        uint coin = SafeEngineLike(safeEngine).coin(handler);
+        uint coin = SafeEngineLike(safeEngine).coinBalance(handler);
         if (coin < mul(amt, RAY)) {
             deltaDebt = toInt(sub(mul(amt, RAY), coin) / rate);
             deltaDebt = mul(uint(deltaDebt), rate) < mul(amt, RAY) ? deltaDebt + 1 : deltaDebt;

--- a/contracts/connectors/reflexer/helpers.sol
+++ b/contracts/connectors/reflexer/helpers.sol
@@ -3,7 +3,14 @@ pragma solidity ^0.7.0;
 import { DSMath } from "../../common/math.sol";
 import { Basic } from "../../common/basic.sol";
 import { TokenInterface } from "../../common/interfaces.sol";
-import { ManagerLike, CoinJoinInterface, SafeEngineLike, TaxCollectorLike, TokenJoinInterface } from "./interface.sol";
+import { 
+    ManagerLike, 
+    CoinJoinInterface, 
+    SafeEngineLike, 
+    TaxCollectorLike, 
+    TokenJoinInterface,
+    GebMapping 
+} from "./interface.sol";
 
 abstract contract Helpers is DSMath, Basic {
     /**
@@ -25,6 +32,18 @@ abstract contract Helpers is DSMath, Basic {
      * @dev Return Close Safe Address.
     */
     address internal constant giveAddr = 0x4dD58550eb15190a5B3DfAE28BB14EeC181fC267;
+
+     /**
+     * @dev Return Reflexer mapping Address.
+     */
+    function getGebMappingAddress() internal pure returns (address) {
+        // TODO: Set the real deployed Reflexer mapping address
+        return 0x0000000000000000000000000000000000000000;
+    }
+
+    function getCollateralJoinAddress(bytes32 collateralType) internal view returns (address) {
+        return GebMapping(getGebMappingAddress()).collateralJoinMapping(collateralType);
+    }
 
     /**
      * @dev Get Safe's collateral type.

--- a/contracts/connectors/reflexer/interface.sol
+++ b/contracts/connectors/reflexer/interface.sol
@@ -1,0 +1,61 @@
+pragma solidity ^0.7.0;
+
+import { TokenInterface } from "../../common/interfaces.sol";
+
+interface ManagerLike {
+    function cdpCan(address, uint, address) external view returns (uint);
+    function ilks(uint) external view returns (bytes32);
+    function last(address) external view returns (uint);
+    function count(address) external view returns (uint);
+    function owns(uint) external view returns (address);
+    function urns(uint) external view returns (address);
+    function vat() external view returns (address);
+    function open(bytes32, address) external returns (uint);
+    function give(uint, address) external;
+    function frob(uint, int, int) external;
+    function flux(uint, address, uint) external;
+    function move(uint, address, uint) external;
+}
+
+interface VatLike {
+    function can(address, address) external view returns (uint);
+    function ilks(bytes32) external view returns (uint, uint, uint, uint, uint);
+    function dai(address) external view returns (uint);
+    function urns(bytes32, address) external view returns (uint, uint);
+    function frob(
+        bytes32,
+        address,
+        address,
+        address,
+        int,
+        int
+    ) external;
+    function hope(address) external;
+    function move(address, address, uint) external;
+    function gem(bytes32, address) external view returns (uint);
+}
+
+interface TokenJoinInterface {
+    function dec() external returns (uint);
+    function gem() external returns (TokenInterface);
+    function join(address, uint) external payable;
+    function exit(address, uint) external;
+}
+
+interface DaiJoinInterface {
+    function vat() external returns (VatLike);
+    function dai() external returns (TokenInterface);
+    function join(address, uint) external payable;
+    function exit(address, uint) external;
+}
+
+interface JugLike {
+    function drip(bytes32) external returns (uint);
+}
+
+interface PotLike {
+    function pie(address) external view returns (uint);
+    function drip() external returns (uint);
+    function join(uint) external;
+    function exit(uint) external;
+}

--- a/contracts/connectors/reflexer/interface.sol
+++ b/contracts/connectors/reflexer/interface.sol
@@ -18,7 +18,7 @@ interface ManagerLike {
 }
 
 interface SafeEngineLike {
-    function can(address, address) external view returns (uint);
+    function safeRights(address, address) external view returns (uint);
     function collateralTypes(bytes32) external view returns (uint, uint, uint, uint, uint);
     function coin(address) external view returns (uint);
     function safes(bytes32, address) external view returns (uint, uint);
@@ -38,6 +38,7 @@ interface SafeEngineLike {
 interface TokenJoinInterface {
     function decimals() external returns (uint);
     function collateral() external returns (TokenInterface);
+    function collateralType() external returns (bytes32);
     function join(address, uint) external payable;
     function exit(address, uint) external;
 }
@@ -51,4 +52,12 @@ interface CoinJoinInterface {
 
 interface TaxCollectorLike {
     function taxSingle(bytes32) external returns (uint);
+}
+
+interface ConnectorsInterface {
+    function chief(address) external view returns (bool);
+}
+
+interface IndexInterface {
+    function master() external view returns (address);
 }

--- a/contracts/connectors/reflexer/interface.sol
+++ b/contracts/connectors/reflexer/interface.sol
@@ -61,3 +61,7 @@ interface ConnectorsInterface {
 interface IndexInterface {
     function master() external view returns (address);
 }
+
+interface GebMapping {
+    function collateralJoinMapping(bytes32) external view returns(address);
+}

--- a/contracts/connectors/reflexer/interface.sol
+++ b/contracts/connectors/reflexer/interface.sol
@@ -20,7 +20,7 @@ interface ManagerLike {
 interface SafeEngineLike {
     function safeRights(address, address) external view returns (uint);
     function collateralTypes(bytes32) external view returns (uint, uint, uint, uint, uint);
-    function coin(address) external view returns (uint);
+    function coinBalance(address) external view returns (uint);
     function safes(bytes32, address) external view returns (uint, uint);
     function modifySAFECollateralization(
         bytes32,
@@ -45,7 +45,7 @@ interface TokenJoinInterface {
 
 interface CoinJoinInterface {
     function safeEngine() external returns (SafeEngineLike);
-    function coin() external returns (TokenInterface);
+    function systemCoin() external returns (TokenInterface);
     function join(address, uint) external payable;
     function exit(address, uint) external;
 }

--- a/contracts/connectors/reflexer/interface.sol
+++ b/contracts/connectors/reflexer/interface.sol
@@ -3,26 +3,26 @@ pragma solidity ^0.7.0;
 import { TokenInterface } from "../../common/interfaces.sol";
 
 interface ManagerLike {
-    function cdpCan(address, uint, address) external view returns (uint);
-    function ilks(uint) external view returns (bytes32);
-    function last(address) external view returns (uint);
-    function count(address) external view returns (uint);
-    function owns(uint) external view returns (address);
-    function urns(uint) external view returns (address);
-    function vat() external view returns (address);
-    function open(bytes32, address) external returns (uint);
-    function give(uint, address) external;
-    function frob(uint, int, int) external;
-    function flux(uint, address, uint) external;
-    function move(uint, address, uint) external;
+    function safeCan(address, uint, address) external view returns (uint);
+    function collateralTypes(uint) external view returns (bytes32);
+    function lastSAFEID(address) external view returns (uint);
+    function safeCount(address) external view returns (uint);
+    function ownsSAFE(uint) external view returns (address);
+    function safes(uint) external view returns (address);
+    function safeEngine() external view returns (address);
+    function openSAFE(bytes32, address) external returns (uint);
+    function transferSAFEOwnership(uint, address) external;
+    function modifySAFECollateralization(uint, int, int) external;
+    function transferCollateral(uint, address, uint) external;
+    function transferInternalCoins(uint, address, uint) external;
 }
 
-interface VatLike {
+interface SafeEngineLike {
     function can(address, address) external view returns (uint);
-    function ilks(bytes32) external view returns (uint, uint, uint, uint, uint);
-    function dai(address) external view returns (uint);
-    function urns(bytes32, address) external view returns (uint, uint);
-    function frob(
+    function collateralTypes(bytes32) external view returns (uint, uint, uint, uint, uint);
+    function coin(address) external view returns (uint);
+    function safes(bytes32, address) external view returns (uint, uint);
+    function modifySAFECollateralization(
         bytes32,
         address,
         address,
@@ -30,32 +30,25 @@ interface VatLike {
         int,
         int
     ) external;
-    function hope(address) external;
-    function move(address, address, uint) external;
-    function gem(bytes32, address) external view returns (uint);
+    function approveSAFEModification(address) external;
+    function transferInternalCoins(address, address, uint) external;
+    function tokenCollateral(bytes32, address) external view returns (uint);
 }
 
 interface TokenJoinInterface {
-    function dec() external returns (uint);
-    function gem() external returns (TokenInterface);
+    function decimals() external returns (uint);
+    function collateral() external returns (TokenInterface);
     function join(address, uint) external payable;
     function exit(address, uint) external;
 }
 
-interface DaiJoinInterface {
-    function vat() external returns (VatLike);
-    function dai() external returns (TokenInterface);
+interface CoinJoinInterface {
+    function safeEngine() external returns (SafeEngineLike);
+    function coin() external returns (TokenInterface);
     function join(address, uint) external payable;
     function exit(address, uint) external;
 }
 
-interface JugLike {
-    function drip(bytes32) external returns (uint);
-}
-
-interface PotLike {
-    function pie(address) external view returns (uint);
-    function drip() external returns (uint);
-    function join(uint) external;
-    function exit(uint) external;
+interface TaxCollectorLike {
+    function taxSingle(bytes32) external returns (uint);
 }

--- a/contracts/connectors/reflexer/main.sol
+++ b/contracts/connectors/reflexer/main.sol
@@ -1,0 +1,484 @@
+pragma solidity ^0.7.0;
+
+import { TokenInterface } from "../../common/interfaces.sol";
+import { Helpers } from "./helpers.sol";
+import { Events } from "./events.sol";
+import { VatLike, TokenJoinInterface } from "./interface.sol";
+
+abstract contract MakerResolver is Helpers, Events {
+    /**
+     * @dev Open Vault
+     * @param colType Type of Collateral.(eg: 'ETH-A')
+    */
+    function open(string calldata colType) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        bytes32 ilk = stringToBytes32(colType);
+        require(instaMapping.gemJoinMapping(ilk) != address(0), "wrong-col-type");
+        uint256 vault = managerContract.open(ilk, address(this));
+
+        _eventName = "LogOpen(uint256,bytes32)";
+        _eventParam = abi.encode(vault, ilk);
+    }
+
+    /**
+     * @dev Close Vault
+     * @param vault Vault ID to close.
+    */
+    function close(uint256 vault) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        uint _vault = getVault(vault);
+        (bytes32 ilk, address urn) = getVaultData(_vault);
+        (uint ink, uint art) = VatLike(managerContract.vat()).urns(ilk, urn);
+
+        require(ink == 0 && art == 0, "vault-has-assets");
+        require(managerContract.owns(_vault) == address(this), "not-owner");
+
+        managerContract.give(_vault, giveAddr);
+
+        _eventName = "LogClose(uint256,bytes32)";
+        _eventParam = abi.encode(_vault, ilk);
+    }
+
+    /**
+     * @dev Deposit ETH/ERC20_Token Collateral.
+     * @param vault Vault ID.
+     * @param amt token amount to deposit.
+     * @param getId Get token amount at this ID from `InstaMemory` Contract.
+     * @param setId Set token amount at this ID in `InstaMemory` Contract.
+    */
+    function deposit(
+        uint256 vault,
+        uint256 amt,
+        uint256 getId,
+        uint256 setId
+    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        uint _amt = getUint(getId, amt);
+        uint _vault = getVault(vault);
+        (bytes32 ilk, address urn) = getVaultData(_vault);
+
+        address colAddr = instaMapping.gemJoinMapping(ilk);
+        TokenJoinInterface tokenJoinContract = TokenJoinInterface(colAddr);
+        TokenInterface tokenContract = tokenJoinContract.gem();
+
+        if (isEth(address(tokenContract))) {
+            _amt = _amt == uint(-1) ? address(this).balance : _amt;
+            tokenContract.deposit{value: _amt}();
+        } else {
+            _amt = _amt == uint(-1) ?  tokenContract.balanceOf(address(this)) : _amt;
+        }
+
+        tokenContract.approve(address(colAddr), _amt);
+        tokenJoinContract.join(address(this), _amt);
+
+        VatLike(managerContract.vat()).frob(
+            ilk,
+            urn,
+            address(this),
+            address(this),
+            toInt(convertTo18(tokenJoinContract.dec(), _amt)),
+            0
+        );
+
+        setUint(setId, _amt);
+
+        _eventName = "LogDeposit(uint256,bytes32,uint256,uint256,uint256)";
+        _eventParam = abi.encode(_vault, ilk, _amt, getId, setId);
+    }
+
+    /**
+     * @dev Withdraw ETH/ERC20_Token Collateral.
+     * @param vault Vault ID.
+     * @param amt token amount to withdraw.
+     * @param getId Get token amount at this ID from `InstaMemory` Contract.
+     * @param setId Set token amount at this ID in `InstaMemory` Contract.
+    */
+    function withdraw(
+        uint256 vault,
+        uint256 amt,
+        uint256 getId,
+        uint256 setId
+    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        uint _amt = getUint(getId, amt);
+        uint _vault = getVault(vault);
+        (bytes32 ilk, address urn) = getVaultData(_vault);
+
+        address colAddr = instaMapping.gemJoinMapping(ilk);
+        TokenJoinInterface tokenJoinContract = TokenJoinInterface(colAddr);
+
+        uint _amt18;
+        if (_amt == uint(-1)) {
+            (_amt18,) = VatLike(managerContract.vat()).urns(ilk, urn);
+            _amt = convert18ToDec(tokenJoinContract.dec(), _amt18);
+        } else {
+            _amt18 = convertTo18(tokenJoinContract.dec(), _amt);
+        }
+
+        managerContract.frob(
+            _vault,
+            -toInt(_amt18),
+            0
+        );
+
+        managerContract.flux(
+            _vault,
+            address(this),
+            _amt18
+        );
+
+        TokenInterface tokenContract = tokenJoinContract.gem();
+
+        if (isEth(address(tokenContract))) {
+            tokenJoinContract.exit(address(this), _amt);
+            tokenContract.withdraw(_amt);
+        } else {
+            tokenJoinContract.exit(address(this), _amt);
+        }
+
+        setUint(setId, _amt);
+
+        _eventName = "LogWithdraw(uint256,bytes32,uint256,uint256,uint256)";
+        _eventParam = abi.encode(_vault, ilk, _amt, getId, setId);
+    }
+
+    /**
+     * @dev Borrow DAI.
+     * @param vault Vault ID.
+     * @param amt token amount to borrow.
+     * @param getId Get token amount at this ID from `InstaMemory` Contract.
+     * @param setId Set token amount at this ID in `InstaMemory` Contract.
+    */
+    function borrow(
+        uint256 vault,
+        uint256 amt,
+        uint256 getId,
+        uint256 setId
+    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        uint _amt = getUint(getId, amt);
+        uint _vault = getVault(vault);
+        (bytes32 ilk, address urn) = getVaultData(_vault);
+
+        VatLike vatContract = VatLike(managerContract.vat());
+
+        managerContract.frob(
+            _vault,
+            0,
+            _getBorrowAmt(
+                address(vatContract),
+                urn,
+                ilk,
+                _amt
+            )
+        );
+
+        managerContract.move(
+            _vault,
+            address(this),
+            toRad(_amt)
+        );
+
+        if (vatContract.can(address(this), address(daiJoinContract)) == 0) {
+            vatContract.hope(address(daiJoinContract));
+        }
+
+        daiJoinContract.exit(address(this), _amt);
+
+        setUint(setId, _amt);
+
+        _eventName = "LogBorrow(uint256,bytes32,uint256,uint256,uint256)";
+        _eventParam = abi.encode(_vault, ilk, _amt, getId, setId);
+    }
+
+    /**
+     * @dev Payback borrowed DAI.
+     * @param vault Vault ID.
+     * @param amt token amount to payback.
+     * @param getId Get token amount at this ID from `InstaMemory` Contract.
+     * @param setId Set token amount at this ID in `InstaMemory` Contract.
+    */
+    function payback(
+        uint256 vault,
+        uint256 amt,
+        uint256 getId,
+        uint256 setId
+    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        uint _amt = getUint(getId, amt);
+        uint _vault = getVault(vault);
+        (bytes32 ilk, address urn) = getVaultData(_vault);
+
+        address vat = managerContract.vat();
+
+        uint _maxDebt = _getVaultDebt(vat, ilk, urn);
+
+        _amt = _amt == uint(-1) ? _maxDebt : _amt;
+
+        require(_maxDebt >= _amt, "paying-excess-debt");
+
+        daiJoinContract.dai().approve(address(daiJoinContract), _amt);
+        daiJoinContract.join(urn, _amt);
+
+        managerContract.frob(
+            _vault,
+            0,
+            _getWipeAmt(
+                vat,
+                VatLike(vat).dai(urn),
+                urn,
+                ilk
+            )
+        );
+
+        setUint(setId, _amt);
+
+        _eventName = "LogPayback(uint256,bytes32,uint256,uint256,uint256)";
+        _eventParam = abi.encode(_vault, ilk, _amt, getId, setId);
+    }
+
+    /**
+     * @dev Withdraw leftover ETH/ERC20_Token after Liquidation.
+     * @param vault Vault ID.
+     * @param amt token amount to Withdraw.
+     * @param getId Get token amount at this ID from `InstaMemory` Contract.
+     * @param setId Set token amount at this ID in `InstaMemory` Contract.
+    */
+    function withdrawLiquidated(
+        uint256 vault,
+        uint256 amt,
+        uint256 getId,
+        uint256 setId
+    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        uint _amt = getUint(getId, amt);
+        (bytes32 ilk, address urn) = getVaultData(vault);
+
+        address colAddr = instaMapping.gemJoinMapping(ilk);
+        TokenJoinInterface tokenJoinContract = TokenJoinInterface(colAddr);
+
+        uint _amt18;
+        if (_amt == uint(-1)) {
+            _amt18 = VatLike(managerContract.vat()).gem(ilk, urn);
+            _amt = convert18ToDec(tokenJoinContract.dec(), _amt18);
+        } else {
+            _amt18 = convertTo18(tokenJoinContract.dec(), _amt);
+        }
+
+        managerContract.flux(
+            vault,
+            address(this),
+            _amt18
+        );
+
+        TokenInterface tokenContract = tokenJoinContract.gem();
+        tokenJoinContract.exit(address(this), _amt);
+        if (isEth(address(tokenContract))) {
+            tokenContract.withdraw(_amt);
+        }
+
+        setUint(setId, _amt);
+
+        _eventName = "LogWithdrawLiquidated(uint256,bytes32,uint256,uint256,uint256)";
+        _eventParam = abi.encode(vault, ilk, _amt, getId, setId);
+    }
+
+    struct MakerData {
+        uint _vault;
+        address colAddr;
+        TokenJoinInterface tokenJoinContract;
+        VatLike vatContract;
+        TokenInterface tokenContract;
+    }
+    /**
+     * @dev Deposit ETH/ERC20_Token Collateral and Borrow DAI.
+     * @param vault Vault ID.
+     * @param depositAmt token deposit amount to Withdraw.
+     * @param borrowAmt token borrow amount to Withdraw.
+     * @param getIdDeposit Get deposit token amount at this ID from `InstaMemory` Contract.
+     * @param getIdBorrow Get borrow token amount at this ID from `InstaMemory` Contract.
+     * @param setIdDeposit Set deposit token amount at this ID in `InstaMemory` Contract.
+     * @param setIdBorrow Set borrow token amount at this ID in `InstaMemory` Contract.
+    */
+    function depositAndBorrow(
+        uint256 vault,
+        uint256 depositAmt,
+        uint256 borrowAmt,
+        uint256 getIdDeposit,
+        uint256 getIdBorrow,
+        uint256 setIdDeposit,
+        uint256 setIdBorrow
+    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        MakerData memory makerData;
+        uint _amtDeposit = getUint(getIdDeposit, depositAmt);
+        uint _amtBorrow = getUint(getIdBorrow, borrowAmt);
+
+        makerData._vault = getVault(vault);
+        (bytes32 ilk, address urn) = getVaultData(makerData._vault);
+
+        makerData.colAddr = instaMapping.gemJoinMapping(ilk);
+        makerData.tokenJoinContract = TokenJoinInterface(makerData.colAddr);
+        makerData.vatContract = VatLike(managerContract.vat());
+        makerData.tokenContract = makerData.tokenJoinContract.gem();
+
+        if (isEth(address(makerData.tokenContract))) {
+            _amtDeposit = _amtDeposit == uint(-1) ? address(this).balance : _amtDeposit;
+            makerData.tokenContract.deposit{value: _amtDeposit}();
+        } else {
+            _amtDeposit = _amtDeposit == uint(-1) ?  makerData.tokenContract.balanceOf(address(this)) : _amtDeposit;
+        }
+
+        makerData.tokenContract.approve(address(makerData.colAddr), _amtDeposit);
+        makerData.tokenJoinContract.join(urn, _amtDeposit);
+
+        managerContract.frob(
+            makerData._vault,
+            toInt(convertTo18(makerData.tokenJoinContract.dec(), _amtDeposit)),
+            _getBorrowAmt(
+                address(makerData.vatContract),
+                urn,
+                ilk,
+                _amtBorrow
+            )
+        );
+
+        managerContract.move(
+            makerData._vault,
+            address(this),
+            toRad(_amtBorrow)
+        );
+
+        if (makerData.vatContract.can(address(this), address(daiJoinContract)) == 0) {
+            makerData.vatContract.hope(address(daiJoinContract));
+        }
+
+        daiJoinContract.exit(address(this), _amtBorrow);
+
+        setUint(setIdDeposit, _amtDeposit);
+        setUint(setIdBorrow, _amtBorrow);
+
+        _eventName = "LogDepositAndBorrow(uint256,bytes32,uint256,uint256,uint256,uint256,uint256,uint256)";
+        _eventParam = abi.encode(
+            makerData._vault,
+            ilk,
+            _amtDeposit,
+            _amtBorrow,
+            getIdDeposit,
+            getIdBorrow,
+            setIdDeposit,
+            setIdBorrow
+        );
+    }
+
+    /**
+     * @dev Exit DAI from urn.
+     * @param vault Vault ID.
+     * @param amt token amount to exit.
+     * @param getId Get token amount at this ID from `InstaMemory` Contract.
+     * @param setId Set token amount at this ID in `InstaMemory` Contract.
+    */
+    function exitDai(
+        uint256 vault,
+        uint256 amt,
+        uint256 getId,
+        uint256 setId
+    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        uint _amt = getUint(getId, amt);
+        uint _vault = getVault(vault);
+        (bytes32 ilk, address urn) = getVaultData(_vault);
+
+        VatLike vatContract = VatLike(managerContract.vat());
+        if(_amt == uint(-1)) {
+            _amt = vatContract.dai(urn);
+            _amt = _amt / 10 ** 27;
+        }
+
+        managerContract.move(
+            _vault,
+            address(this),
+            toRad(_amt)
+        );
+
+        if (vatContract.can(address(this), address(daiJoinContract)) == 0) {
+            vatContract.hope(address(daiJoinContract));
+        }
+
+        daiJoinContract.exit(address(this), _amt);
+
+        setUint(setId, _amt);
+
+        _eventName = "LogExitDai(uint256,bytes32,uint256,uint256,uint256)";
+        _eventParam = abi.encode(_vault, ilk, _amt, getId, setId);
+    }
+
+    /**
+     * @dev Deposit DAI in DSR.
+     * @param amt DAI amount to deposit.
+     * @param getId Get token amount at this ID from `InstaMemory` Contract.
+     * @param setId Set token amount at this ID in `InstaMemory` Contract.
+    */
+    function depositDai(
+        uint256 amt,
+        uint256 getId,
+        uint256 setId
+    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        uint _amt = getUint(getId, amt);
+
+        _amt = _amt == uint(-1) ?
+            daiJoinContract.dai().balanceOf(address(this)) :
+            _amt;
+
+        VatLike vat = daiJoinContract.vat();
+        uint chi = potContract.drip();
+
+        daiJoinContract.dai().approve(address(daiJoinContract), _amt);
+        daiJoinContract.join(address(this), _amt);
+        if (vat.can(address(this), address(potContract)) == 0) {
+            vat.hope(address(potContract));
+        }
+
+        potContract.join(mul(_amt, RAY) / chi);
+        setUint(setId, _amt);
+
+        _eventName = "LogDepositDai(uint256,uint256,uint256)";
+        _eventParam = abi.encode(_amt, getId, setId);
+    }
+
+    /**
+     * @dev Withdraw DAI from DSR.
+     * @param amt DAI amount to withdraw.
+     * @param getId Get token amount at this ID from `InstaMemory` Contract.
+     * @param setId Set token amount at this ID in `InstaMemory` Contract.
+    */
+    function withdrawDai(
+        uint256 amt,
+        uint256 getId,
+        uint256 setId
+    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        uint _amt = getUint(getId, amt);
+
+        VatLike vat = daiJoinContract.vat();
+
+        uint chi = potContract.drip();
+        uint pie;
+        if (_amt == uint(-1)) {
+            pie = potContract.pie(address(this));
+            _amt = mul(chi, pie) / RAY;
+        } else {
+            pie = mul(_amt, RAY) / chi;
+        }
+
+        potContract.exit(pie);
+
+        uint bal = vat.dai(address(this));
+        if (vat.can(address(this), address(daiJoinContract)) == 0) {
+            vat.hope(address(daiJoinContract));
+        }
+        daiJoinContract.exit(
+            address(this),
+            bal >= mul(_amt, RAY) ? _amt : bal / RAY
+        );
+
+        setUint(setId, _amt);
+
+        _eventName = "LogWithdrawDai(uint256,uint256,uint256)";
+        _eventParam = abi.encode(_amt, getId, setId);
+    }
+}
+
+contract ConnectV2Maker is MakerResolver {
+    string public constant name = "MakerDao-v1";
+}

--- a/contracts/connectors/reflexer/main.sol
+++ b/contracts/connectors/reflexer/main.sol
@@ -134,7 +134,7 @@ abstract contract GebResolver is Helpers, Events {
 
         setUint(setId, _amt);
 
-        _eventName = "LogWithdrawCoin(uint256,bytes32,uint256,uint256,uint256)";
+        _eventName = "LogWithdraw(uint256,bytes32,uint256,uint256,uint256)";
         _eventParam = abi.encode(_safe, collateralType, _amt, getId, setId);
     }
 

--- a/contracts/connectors/reflexer/main.sol
+++ b/contracts/connectors/reflexer/main.sol
@@ -12,7 +12,7 @@ abstract contract GebResolver is Helpers, Events {
     */
     function open(string calldata colType) external payable returns (string memory _eventName, bytes memory _eventParam) {
         bytes32 collateralType = stringToBytes32(colType);
-        require(instaMapping.gemJoinMapping(collateralType) != address(0), "wrong-col-type");
+        require(getCollateralJoinAddress(collateralType) != address(0), "wrong-col-type");
         uint256 safe = managerContract.openSAFE(collateralType, address(this));
 
         _eventName = "LogOpen(uint256,bytes32)";
@@ -54,7 +54,7 @@ abstract contract GebResolver is Helpers, Events {
         uint _safe = getSafe(safe);
         (bytes32 collateralType, address handler) = getSafeData(_safe);
 
-        address colAddr = instaMapping.gemJoinMapping(collateralType);
+        address colAddr = getCollateralJoinAddress(collateralType);
         TokenJoinInterface tokenJoinContract = TokenJoinInterface(colAddr);
         TokenInterface tokenContract = tokenJoinContract.collateral();
 
@@ -100,7 +100,7 @@ abstract contract GebResolver is Helpers, Events {
         uint _safe = getSafe(safe);
         (bytes32 collateralType, address handler) = getSafeData(_safe);
 
-        address colAddr = instaMapping.gemJoinMapping(collateralType);
+        address colAddr = getCollateralJoinAddress(collateralType);
         TokenJoinInterface tokenJoinContract = TokenJoinInterface(colAddr);
 
         uint _amt18;
@@ -247,7 +247,7 @@ abstract contract GebResolver is Helpers, Events {
         uint _amt = getUint(getId, amt);
         (bytes32 collateralType, address handler) = getSafeData(safe);
 
-        address colAddr = instaMapping.gemJoinMapping(collateralType);
+        address colAddr = getCollateralJoinAddress(collateralType);
         TokenJoinInterface tokenJoinContract = TokenJoinInterface(colAddr);
 
         uint _amt18;
@@ -309,7 +309,7 @@ abstract contract GebResolver is Helpers, Events {
         gebData._safe = getSafe(safe);
         (bytes32 collateralType, address handler) = getSafeData(gebData._safe);
 
-        gebData.colAddr = instaMapping.gemJoinMapping(collateralType);
+        gebData.colAddr = getCollateralJoinAddress(collateralType);
         gebData.tokenJoinContract = TokenJoinInterface(gebData.colAddr);
         gebData.safeEngineContract = SafeEngineLike(managerContract.safeEngine());
         gebData.tokenContract = gebData.tokenJoinContract.collateral();

--- a/contracts/connectors/reflexer/main.sol
+++ b/contracts/connectors/reflexer/main.sol
@@ -79,7 +79,7 @@ abstract contract GebResolver is Helpers, Events {
 
         setUint(setId, _amt);
 
-        _eventName = "LogDepositCoin(uint256,bytes32,uint256,uint256,uint256)";
+        _eventName = "LogDeposit(uint256,bytes32,uint256,uint256,uint256)";
         _eventParam = abi.encode(_safe, collateralType, _amt, getId, setId);
     }
 

--- a/contracts/connectors/reflexer/main.sol
+++ b/contracts/connectors/reflexer/main.sol
@@ -79,7 +79,7 @@ abstract contract GebResolver is Helpers, Events {
 
         setUint(setId, _amt);
 
-        _eventName = "LogDeposit(uint256,bytes32,uint256,uint256,uint256)";
+        _eventName = "LogDepositCoin(uint256,bytes32,uint256,uint256,uint256)";
         _eventParam = abi.encode(_safe, collateralType, _amt, getId, setId);
     }
 
@@ -134,7 +134,7 @@ abstract contract GebResolver is Helpers, Events {
 
         setUint(setId, _amt);
 
-        _eventName = "LogWithdraw(uint256,bytes32,uint256,uint256,uint256)";
+        _eventName = "LogWithdrawCoin(uint256,bytes32,uint256,uint256,uint256)";
         _eventParam = abi.encode(_safe, collateralType, _amt, getId, setId);
     }
 

--- a/contracts/connectors/reflexer/main.sol
+++ b/contracts/connectors/reflexer/main.sol
@@ -211,7 +211,7 @@ abstract contract GebResolver is Helpers, Events {
 
         require(_maxDebt >= _amt, "paying-excess-debt");
 
-        coinJoinContract.coin().approve(address(coinJoinContract), _amt);
+        coinJoinContract.systemCoin().approve(address(coinJoinContract), _amt);
         coinJoinContract.join(handler, _amt);
 
         managerContract.modifySAFECollateralization(
@@ -219,7 +219,7 @@ abstract contract GebResolver is Helpers, Events {
             0,
             _getWipeAmt(
                 safeEngine,
-                SafeEngineLike(safeEngine).coin(handler),
+                SafeEngineLike(safeEngine).coinBalance(handler),
                 handler,
                 collateralType
             )
@@ -382,7 +382,7 @@ abstract contract GebResolver is Helpers, Events {
 
         SafeEngineLike safeEngineContract = SafeEngineLike(managerContract.safeEngine());
         if(_amt == uint(-1)) {
-            _amt = safeEngineContract.coin(handler);
+            _amt = safeEngineContract.coinBalance(handler);
             _amt = _amt / 10 ** 27;
         }
 

--- a/contracts/mapping/reflexer.sol
+++ b/contracts/mapping/reflexer.sol
@@ -1,0 +1,57 @@
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+interface CollateralJoinInterface {
+    function collateralType() external view returns (bytes32);
+}
+
+interface ConnectorsInterface {
+    function chief(address) external view returns (bool);
+}
+
+interface IndexInterface {
+    function master() external view returns (address);
+}
+
+
+contract Helpers {
+    address public constant connectors = 0xD6A602C01a023B98Ecfb29Df02FBA380d3B21E0c;
+    address public constant instaIndex = 0x2971AdFa57b20E5a416aE5a708A8655A9c74f723;
+    uint public version = 1;
+
+    mapping (bytes32 => address) public collateralJoinMapping;
+
+    event LogAddCollateralJoinMapping(address[] collateralJoin);
+    
+    modifier isChief {
+        require(
+            ConnectorsInterface(connectors).chief(msg.sender) ||
+            IndexInterface(instaIndex).master() == msg.sender, "not-Chief");
+        _;
+    }
+
+    function addCollateralJoinMapping(address[] memory collateralJoins) public isChief {
+        _addCollateralJoinMapping(collateralJoins);
+    }
+
+    function _addCollateralJoinMapping(address[] memory collateralJoins) internal {
+        require(collateralJoins.length > 0, "No-CollateralJoin-Address");
+        for(uint i = 0; i < collateralJoins.length; i++) {
+            address collateralJoin = collateralJoins[i];
+            bytes32 collateralType = CollateralJoinInterface(collateralJoin).collateralType();
+            require(collateralJoinMapping[collateralType] == address(0), "CollateralJoin-Already-Added");
+            collateralJoinMapping[collateralType] = collateralJoin;
+        }
+        emit LogAddCollateralJoinMapping(collateralJoins);
+    }
+
+}
+
+contract GebMapping is Helpers {
+    string constant public name = "Reflexer-Mapping-v1";
+    constructor() public {
+        address[] memory collateralJoins = new address[](1);
+        collateralJoins[0] = 0x2D3cD7b81c93f188F3CB8aD87c8Acc73d6226e3A; // ETH-A Join contract address
+        _addCollateralJoinMapping(collateralJoins); 
+    }
+}


### PR DESCRIPTION
Hey, this is the connector PR. I tested every functions on a hardhat mainnet fork.

Breaking changes compared to the Maker connector: 
- Events `LogExitDai`, `LogDepositDai` and `LogWithdrawDai` were renamed
- exitDai was renamed exit and its return event was adjusted accordingly. 
- Removed everything DSR related (Since we don't have a DSR)

Note: 
- I'm not sure what is the `giveAddr` is and if it should be updated
- I noticed a mismatch in the Maker contract between the event names [here](https://github.com/InstaDApp/dsa-connectors-new/blob/81a3f0b0b86407c912dc78d07b747d301499a424/contracts/connectors/makerdao/main.sol#L85) and [here](https://github.com/InstaDApp/dsa-connectors-new/blob/81a3f0b0b86407c912dc78d07b747d301499a424/contracts/connectors/makerdao/events.sol#L13). There is the same issue for the withdrawal event. In my code, I assumed it was a mistake. 
- Since in the other connectors you are harcoding the address of the mapping contract, I hardcoded the Reflexer mapping address as well in `getGebMappingAddress`. It will need to be updated once the mapping is deployed. 