### PR TITLE
Handle repayments in adjust() and upate tests

### DIFF
--- a/contracts/mainnet/connectors/liquity/helpers.sol
+++ b/contracts/mainnet/connectors/liquity/helpers.sol
@@ -29,8 +29,7 @@ abstract contract Helpers is DSMath, Basic {
         uint maxFeePercentage;
         uint withdrawAmount;
         uint depositAmount;
-        uint borrowAmount;
-        uint repayAmount;
+        uint lusdChange;
         bool isBorrow;
     }
 

--- a/contracts/mainnet/connectors/liquity/main.sol
+++ b/contracts/mainnet/connectors/liquity/main.sol
@@ -226,7 +226,7 @@ abstract contract LiquityResolver is Events, Helpers {
         withdrawAmount = getUint(getIds[1], withdrawAmount);
         adjustTrove.withdrawAmount = withdrawAmount == uint(-1) ? troveManager.getTroveColl(address(this)) : withdrawAmount;
 
-        adjustTrove.borrowAmount = getUint(getIds[2], borrowAmount);
+        borrowAmount = getUint(getIds[2], borrowAmount);
 
         repayAmount = getUint(getIds[3], repayAmount);
         if (repayAmount == uint(-1)) {
@@ -234,14 +234,14 @@ abstract contract LiquityResolver is Events, Helpers {
             uint _totalDebt = troveManager.getTroveDebt(address(this));
             repayAmount = _lusdBal > _totalDebt ? _totalDebt : _lusdBal;
         }
-        adjustTrove.repayAmount = repayAmount;
 
         adjustTrove.isBorrow = borrowAmount > 0;
-
+        adjustTrove.lusdChange = adjustTrove.isBorrow ? borrowAmount : repayAmount;
+        
         borrowerOperations.adjustTrove{value: adjustTrove.depositAmount}(
             adjustTrove.maxFeePercentage,
             adjustTrove.withdrawAmount,
-            adjustTrove.borrowAmount,
+            adjustTrove.lusdChange,
             adjustTrove.isBorrow,
             upperHint,
             lowerHint
@@ -249,11 +249,11 @@ abstract contract LiquityResolver is Events, Helpers {
         
         setUint(setIds[0], adjustTrove.depositAmount);
         setUint(setIds[1], adjustTrove.withdrawAmount);
-        setUint(setIds[2], adjustTrove.borrowAmount);
-        setUint(setIds[3], adjustTrove.repayAmount);
+        setUint(setIds[2], borrowAmount);
+        setUint(setIds[3], repayAmount);
 
         _eventName = "LogAdjust(address,uint256,uint256,uint256,uint256,uint256,uint256[],uint256[])";
-        _eventParam = abi.encode(address(this), maxFeePercentage, adjustTrove.depositAmount, adjustTrove.withdrawAmount, adjustTrove.borrowAmount, adjustTrove.repayAmount, getIds, setIds);
+        _eventParam = abi.encode(address(this), maxFeePercentage, adjustTrove.depositAmount, adjustTrove.withdrawAmount, borrowAmount, repayAmount, getIds, setIds);
     }
 
     /**

--- a/test/liquity/liquity.test.js
+++ b/test/liquity/liquity.test.js
@@ -1208,7 +1208,7 @@ describe("Liquity", () => {
           const depositAmount = 0;
           const borrowAmount = 0;
           const withdrawAmount = ethers.utils.parseEther("1"); // 1 ETH;
-          const repayAmount = ethers.utils.parseUnits("500", 18); // 500 LUSD;
+          const repayAmount = ethers.utils.parseUnits("10", 18); // 10 LUSD;
           const { upperHint, lowerHint } = await helpers.getTroveInsertionHints(
             troveCollateralBefore.sub(withdrawAmount),
             troveDebtBefore.sub(repayAmount),
@@ -1256,7 +1256,7 @@ describe("Liquity", () => {
 
           expect(
             troveDebt,
-            `Trove debt should have increased by at least ${borrowAmount} ETH`
+            `Trove debt should have decreased by at least ${repayAmount} LUSD`
           ).to.gte(expectedTroveDebt);
         });
 
@@ -1273,7 +1273,7 @@ describe("Liquity", () => {
           const depositAmount = ethers.utils.parseEther("1"); // 1 ETH
           const borrowAmount = 0;
           const withdrawAmount = 0;
-          const repayAmount = ethers.utils.parseUnits("100", 18); // 100 lUSD
+          const repayAmount = ethers.utils.parseUnits("10", 18); // 10 lUSD
           const upperHint = ethers.constants.AddressZero;
           const lowerHint = ethers.constants.AddressZero;
           const maxFeePercentage = ethers.utils.parseUnits("0.5", 18); // 0.5% max fee
@@ -1304,7 +1304,7 @@ describe("Liquity", () => {
               0, // Repay amount comes from a previous spell's storage slot
               upperHint,
               lowerHint,
-              [ethDepositId, 0, 0, 0],
+              [ethDepositId, 0, 0, lusdRepayId],
               [0, 0, 0, 0],
             ],
           };
@@ -1323,7 +1323,7 @@ describe("Liquity", () => {
             .connect(userWallet)
             .approve(dsa.address, repayAmount);
 
-          // Adjust Trove by depositing ETH and borrowing LUSD
+          // Adjust Trove by depositing ETH and repaying LUSD
           await dsa
             .connect(userWallet)
             .cast(...encodeSpells(spells), userWallet.address, {
@@ -1338,7 +1338,7 @@ describe("Liquity", () => {
             dsa.address
           );
           const expectedTroveColl = troveCollateralBefore.add(depositAmount);
-          const expectedTroveDebt = troveDebtBefore.add(borrowAmount);
+          const expectedTroveDebt = troveDebtBefore.sub(repayAmount);
 
           expect(
             troveCollateral,
@@ -1347,7 +1347,7 @@ describe("Liquity", () => {
 
           expect(
             troveDebt,
-            `Trove debt should have increased by at least ${borrowAmount} ETH`
+            `Trove debt (${troveDebtBefore}) should have decreased by at least ${repayAmount} LUSD`
           ).to.eq(expectedTroveDebt);
         });
 


### PR DESCRIPTION
Liquity core's `adjust()` function handles repayments by supplying the same parameter as the borrow amount, but switching the `isBorrowing` boolean to false. This was being handled incorrectly in the Instadapp DSA connector.

We now use `lusdChange` in the AdjustTrove struct, to match what Liquity core expects.