### PR TITLE
Update GUNI staking connector

### DIFF
--- a/contracts/mainnet/connectors/guniswap_v3_erc20_staking/events.sol
+++ b/contracts/mainnet/connectors/guniswap_v3_erc20_staking/events.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.7.0;
 contract Events {
 
   event LogDeposit(
-    address indexed stakingToken,
+    address indexed stakingPool,
     uint256 amount,
     uint getId,
     uint setId
   );
 
   event LogWithdrawAndClaimedReward(
-    address indexed stakingToken,
+    address indexed stakingPool,
     uint256 amount,
     uint256 rewardAmt,
     uint getId,
@@ -19,6 +19,7 @@ contract Events {
   );
 
   event LogClaimedReward(
+    address indexed stakingPool,
     address indexed rewardToken,
     uint256 rewardAmt,
     uint setId

--- a/contracts/mainnet/connectors/guniswap_v3_erc20_staking/helpers.sol
+++ b/contracts/mainnet/connectors/guniswap_v3_erc20_staking/helpers.sol
@@ -8,17 +8,5 @@ import { TokenInterface } from "../../common/interfaces.sol";
 import { IStakingRewards, IStakingRewardsFactory, IGUniPoolResolver } from "./interface.sol";
 
 abstract contract Helpers is DSMath, Basic {
-
-  IGUniPoolResolver constant internal guniResolver = 
-    IGUniPoolResolver(0x729BF02a9A786529Fc80498f8fd0051116061B13);
-
   TokenInterface constant internal rewardToken = TokenInterface(0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb);
-
-  function getStakingContract(address stakingToken) internal view returns (address) {
-    IStakingRewardsFactory.StakingRewardsInfo memory stakingRewardsInfo =
-      guniResolver.getStakingFactory().stakingRewardsInfoByStakingToken(stakingToken);
-
-    return stakingRewardsInfo.stakingRewards;
-  }
-
 }

--- a/contracts/mainnet/connectors/guniswap_v3_erc20_staking/main.sol
+++ b/contracts/mainnet/connectors/guniswap_v3_erc20_staking/main.sol
@@ -17,12 +17,14 @@ contract Main is Helpers, Events {
   /**
     * @dev Deposit ERC20.
     * @notice Deposit Tokens to staking pool.
+    * @param stakingPool staking pool address.
     * @param stakingToken staking token address.
     * @param amt staking token amount.
     * @param getId ID to retrieve amount.
     * @param setId ID stores the amount of staked tokens.
   */
   function deposit(
+    address stakingPool,
     address stakingToken,
     uint amt,
     uint getId,
@@ -30,7 +32,7 @@ contract Main is Helpers, Events {
   ) external payable returns (string memory _eventName, bytes memory _eventParam) {
     uint _amt = getUint(getId, amt);
     
-    IStakingRewards stakingContract = IStakingRewards(getStakingContract(stakingToken));
+    IStakingRewards stakingContract = IStakingRewards(stakingPool);
     TokenInterface stakingTokenContract = TokenInterface(stakingToken);
 
     _amt = _amt == uint(-1) ? stakingTokenContract.balanceOf(address(this)) : _amt;
@@ -40,12 +42,13 @@ contract Main is Helpers, Events {
 
     setUint(setId, _amt);
     _eventName = "LogDeposit(address,uint256,uint256,uint256)";
-    _eventParam = abi.encode(address(stakingToken), _amt, getId, setId);
+    _eventParam = abi.encode(address(stakingPool), _amt, getId, setId);
   }
 
   /**
     * @dev Withdraw ERC20.
     * @notice Withdraw Tokens from the staking pool.
+    * @param stakingPool staking pool address.
     * @param stakingToken staking token address.
     * @param amt staking token amount.
     * @param getId ID to retrieve amount.
@@ -53,6 +56,7 @@ contract Main is Helpers, Events {
     * @param setIdReward ID stores the amount of reward tokens claimed.
   */
   function withdraw(
+    address stakingPool,
     address stakingToken,
     uint amt,
     uint getId,
@@ -61,7 +65,7 @@ contract Main is Helpers, Events {
   ) external payable returns (string memory _eventName, bytes memory _eventParam) {
     uint _amt = getUint(getId, amt);
 
-    IStakingRewards stakingContract = IStakingRewards(getStakingContract(stakingToken));
+    IStakingRewards stakingContract = IStakingRewards(stakingPool);
 
     _amt = _amt == uint(-1) ? stakingContract.balanceOf(address(this)) : _amt;
     uint intialBal = rewardToken.balanceOf(address(this));
@@ -74,21 +78,21 @@ contract Main is Helpers, Events {
     setUint(setIdReward, rewardAmt);
     {
     _eventName = "LogWithdrawAndClaimedReward(address,uint256,uint256,uint256,uint256,uint256)";
-    _eventParam = abi.encode(address(stakingToken), _amt, rewardAmt, getId, setIdAmount, setIdReward);
+    _eventParam = abi.encode(address(stakingPool), _amt, rewardAmt, getId, setIdAmount, setIdReward);
     }
   }
 
   /**
     * @dev Claim Reward.
     * @notice Claim Pending Rewards of tokens staked.
-    * @param stakingToken staking token address.
+    * @param stakingPool staking pool address.
     * @param setId ID stores the amount of reward tokens claimed.
   */
   function claimReward(
-    address stakingToken,
+    address stakingPool,
     uint setId
   ) external payable returns (string memory _eventName, bytes memory _eventParam) {
-    IStakingRewards stakingContract = IStakingRewards(getStakingContract(stakingToken));
+    IStakingRewards stakingContract = IStakingRewards(stakingPool);
 
     uint intialBal = rewardToken.balanceOf(address(this));
     stakingContract.getReward();
@@ -97,12 +101,12 @@ contract Main is Helpers, Events {
     uint rewardAmt = sub(finalBal, intialBal);
 
     setUint(setId, rewardAmt);
-    _eventName = "LogClaimedReward(address,uint256,uint256)";
-    _eventParam = abi.encode(address(rewardToken), rewardAmt, setId);
+    _eventName = "LogClaimedReward(address,address,uint256,uint256)";
+    _eventParam = abi.encode(address(stakingPool), address(rewardToken), rewardAmt, setId);
   }
 
 }
 
 contract connectV2StakeGUNI is Main {
-    string public constant name = "Stake-G-UNI-v1.0";
+    string public constant name = "Stake-G-UNI-v1.1";
 }


### PR DESCRIPTION
Updated GUNI staking connector to take `stakingPool` address instead of mapping it from `stakingToken`.