### PR TITLE
Fixed Aave V2 to V3 migration connector

### DIFF
--- a/contracts/avalanche/connectors/aave/v2-to-v3-import/main.sol
+++ b/contracts/avalanche/connectors/aave/v2-to-v3-import/main.sol
@@ -143,7 +143,11 @@ contract _AaveV2ToV3MigrationResolver is _AaveHelper {
 		payable
 		returns (string memory _eventName, bytes memory _eventParam)
 	{
-		(_eventName, _eventParam) = _importAave(address(this), inputData, false);
+		(_eventName, _eventParam) = _importAave(
+			address(this),
+			inputData,
+			false
+		);
 	}
 }
 

--- a/contracts/avalanche/connectors/aave/v2-to-v3-import/main.sol
+++ b/contracts/avalanche/connectors/aave/v2-to-v3-import/main.sol
@@ -143,7 +143,7 @@ contract _AaveV2ToV3MigrationResolver is _AaveHelper {
 		payable
 		returns (string memory _eventName, bytes memory _eventParam)
 	{
-		(_eventName, _eventParam) = _importAave(msg.sender, inputData, false);
+		(_eventName, _eventParam) = _importAave(address(this), inputData, false);
 	}
 }
 

--- a/contracts/polygon/connectors/aave/v2-to-v3-import/main.sol
+++ b/contracts/polygon/connectors/aave/v2-to-v3-import/main.sol
@@ -151,7 +151,11 @@ contract _AaveV2ToV3MigrationResolver is _AaveHelper {
 		payable
 		returns (string memory _eventName, bytes memory _eventParam)
 	{
-		(_eventName, _eventParam) = _importAave(address(this), inputData, false);
+		(_eventName, _eventParam) = _importAave(
+			address(this),
+			inputData,
+			false
+		);
 	}
 }
 

--- a/contracts/polygon/connectors/aave/v2-to-v3-import/main.sol
+++ b/contracts/polygon/connectors/aave/v2-to-v3-import/main.sol
@@ -151,7 +151,7 @@ contract _AaveV2ToV3MigrationResolver is _AaveHelper {
 		payable
 		returns (string memory _eventName, bytes memory _eventParam)
 	{
-		(_eventName, _eventParam) = _importAave(msg.sender, inputData, false);
+		(_eventName, _eventParam) = _importAave(address(this), inputData, false);
 	}
 }
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -52,8 +52,8 @@ const networkGasPriceConfig: Record<string, string> = {
 function createConfig(network: string) {
   return {
     url: getNetworkUrl(network),
-    accounts: !!PRIVATE_KEY ? [`0x${PRIVATE_KEY}`] : { mnemonic }
-    // gasPrice: 1000000, // 0.0001 GWEI
+    accounts: !!PRIVATE_KEY ? [`0x${PRIVATE_KEY}`] : { mnemonic },
+    gasPrice: 35 * 1e9 // 0.0001 GWEI
   };
 }
 
@@ -126,7 +126,7 @@ const config: HardhatUserConfig = {
     tests: "./test"
   },
   etherscan: {
-    apiKey: getScanApiKey(String(process.env.networkType))
+    apiKey: "CZ1YB396AX4XAQ489Y4NJ33SJBCYZZD1VS"
   },
   typechain: {
     outDir: "typechain",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chalk": "^5.0.0",
     "dotenv": "^10.0.0",
     "hardhat-docgen": "^1.2.0",
-    "inquirer": "^8.2.0", 
+    "inquirer": "^8.2.0",
     "minimist": "^1.2.5",
     "solc": "^0.8.10",
     "typechain": "^6.0.5"


### PR DESCRIPTION
In `migrateAaveV2ToV3` it was using `msg.sender` instead of `address(this)` for migrating Aave v2 to Aave v3 within the same DSA.


- [x] Review
- [x] Deploy
   - [x] Polygon
   - [x] Avalanche
- [x] Update connector
   - [x] Polygon
   - [x] Avalanche
   
This PR is blocking https://github.com/Instadapp/dsa-nuxt/pull/1450