### PR TITLE
Aave v3 import fix

### DIFF
--- a/contracts/arbitrum/connectors/aave/v3-import/events.sol
+++ b/contracts/arbitrum/connectors/aave/v3-import/events.sol
@@ -12,4 +12,14 @@ contract Events {
 		uint256[] supplyAmts,
 		uint256[] borrowAmts
 	);
+	event LogAaveV3ImportWithCollateral(
+		address indexed user,
+		address[] ctokens,
+		string[] supplyIds,
+		string[] borrowIds,
+		uint256[] flashLoanFees,
+		uint256[] supplyAmts,
+		uint256[] borrowAmts,
+		bool[] enableCollateral
+	);
 }

--- a/contracts/arbitrum/connectors/aave/v3-import/helpers.sol
+++ b/contracts/arbitrum/connectors/aave/v3-import/helpers.sol
@@ -250,6 +250,34 @@ contract AaveHelpers is Helper {
 		}
 	}
 
+	function _TransferAtokensWithCollateral(
+		uint256 _length,
+		AaveInterface aave,
+		ATokenInterface[] memory atokenContracts,
+		uint256[] memory amts,
+		address[] memory tokens,
+		bool[] memory colEnable,
+		address userAccount
+	) internal {
+		for (uint256 i = 0; i < _length; i++) {
+			if (amts[i] > 0) {
+				uint256 _amt = amts[i];
+				require(
+					atokenContracts[i].transferFrom(
+						userAccount,
+						address(this),
+						_amt
+					),
+					"allowance?"
+				);
+
+				if (!getIsColl(tokens[i], address(this))) {
+					aave.setUserUseReserveAsCollateral(tokens[i], colEnable[i]);
+				}
+			}
+		}
+	}
+
 	function _BorrowVariable(
 		uint256 _length,
 		AaveInterface aave,

--- a/contracts/arbitrum/connectors/aave/v3-import/main.sol
+++ b/contracts/arbitrum/connectors/aave/v3-import/main.sol
@@ -91,6 +91,89 @@ contract AaveV3ImportResolver is AaveHelpers {
 		);
 	}
 
+	function _importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		internal
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		require(
+			AccountInterface(address(this)).isAuth(userAccount),
+			"user-account-not-auth"
+		);
+
+		require(inputData.supplyTokens.length > 0, "0-length-not-allowed");
+		require(enableCollateral.length == inputData.supplyTokens.length, "lengths-not-same");
+
+		ImportData memory data;
+
+		AaveInterface aave = AaveInterface(aaveProvider.getPool());
+
+		data = getBorrowAmounts(userAccount, aave, inputData, data);
+		data = getSupplyAmounts(userAccount, inputData, data);
+
+		//  payback borrowed amount;
+		_PaybackStable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.stableBorrowAmts,
+			userAccount
+		);
+		_PaybackVariable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.variableBorrowAmts,
+			userAccount
+		);
+
+		//  transfer atokens to this address;
+		_TransferAtokensWithCollateral(
+			data._supplyTokens.length,
+			aave,
+			data.aTokens,
+			data.supplyAmts,
+			data._supplyTokens,
+			enableCollateral,
+			userAccount
+		);
+
+		// borrow assets after migrating position
+		if (data.convertStable) {
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.totalBorrowAmtsWithFee
+			);
+		} else {
+			_BorrowStable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.stableBorrowAmtsWithFee
+			);
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.variableBorrowAmtsWithFee
+			);
+		}
+
+		_eventName = "LogAaveV3ImportWithCollateral(address,bool,address[],address[],uint256[],uint256[],uint256[],uint256[],bool[])";
+		_eventParam = abi.encode(
+			userAccount,
+			inputData.convertStable,
+			inputData.supplyTokens,
+			inputData.borrowTokens,
+			inputData.flashLoanFees,
+			data.supplyAmts,
+			data.stableBorrowAmts,
+			data.variableBorrowAmts,
+			enableCollateral
+		);
+	}
+
 	/**
 	 * @dev Import aave V3 position .
 	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
@@ -104,8 +187,23 @@ contract AaveV3ImportResolver is AaveHelpers {
 	{
 		(_eventName, _eventParam) = _importAave(userAccount, inputData);
 	}
+
+	/**
+	 * @dev Import aave V3 position (with collateral).
+	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
+	 * @param userAccount The address of the EOA from which aave position will be imported
+	 * @param inputData The struct containing all the neccessary input data
+	 * @param enableCollateral The boolean array to enable selected collaterals in the imported position
+	 */
+	function importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		external
+		payable
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		(_eventName, _eventParam) = _importAaveWithCollateral(userAccount, inputData, enableCollateral);
+	}
 }
 
 contract ConnectV2AaveV3ImportArbitrum is AaveV3ImportResolver {
-	string public constant name = "Aave-v3-import-v1";
+	string public constant name = "Aave-v3-import-v1.1";
 }

--- a/contracts/avalanche/connectors/aave/v3-import/events.sol
+++ b/contracts/avalanche/connectors/aave/v3-import/events.sol
@@ -5,11 +5,21 @@ pragma experimental ABIEncoderV2;
 contract Events {
 	event LogAaveV3Import(
 		address indexed user,
-		address[] ctokens,
+		address[] atokens,
 		string[] supplyIds,
 		string[] borrowIds,
 		uint256[] flashLoanFees,
 		uint256[] supplyAmts,
 		uint256[] borrowAmts
+	);
+	event LogAaveV3ImportWithCollateral(
+		address indexed user,
+		address[] atokens,
+		string[] supplyIds,
+		string[] borrowIds,
+		uint256[] flashLoanFees,
+		uint256[] supplyAmts,
+		uint256[] borrowAmts,
+		bool[] enableCollateral
 	);
 }

--- a/contracts/avalanche/connectors/aave/v3-import/helpers.sol
+++ b/contracts/avalanche/connectors/aave/v3-import/helpers.sol
@@ -252,6 +252,34 @@ contract AaveHelpers is Helper {
 		}
 	}
 
+	function _TransferAtokensWithCollateral(
+		uint256 _length,
+		AaveInterface aave,
+		ATokenInterface[] memory atokenContracts,
+		uint256[] memory amts,
+		address[] memory tokens,
+		bool[] memory colEnable,
+		address userAccount
+	) internal {
+		for (uint256 i = 0; i < _length; i++) {
+			if (amts[i] > 0) {
+				uint256 _amt = amts[i];
+				require(
+					atokenContracts[i].transferFrom(
+						userAccount,
+						address(this),
+						_amt
+					),
+					"allowance?"
+				);
+
+				if (!getIsColl(tokens[i], address(this))) {
+					aave.setUserUseReserveAsCollateral(tokens[i], colEnable[i]);
+				}
+			}
+		}
+	}
+
 	function _BorrowVariable(
 		uint256 _length,
 		AaveInterface aave,

--- a/contracts/avalanche/connectors/aave/v3-import/main.sol
+++ b/contracts/avalanche/connectors/aave/v3-import/main.sol
@@ -91,6 +91,89 @@ contract AaveV3ImportResolver is AaveHelpers {
 		);
 	}
 
+	function _importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		internal
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		require(
+			AccountInterface(address(this)).isAuth(userAccount),
+			"user-account-not-auth"
+		);
+
+		require(inputData.supplyTokens.length > 0, "0-length-not-allowed");
+		require(enableCollateral.length == inputData.supplyTokens.length, "lengths-not-same");
+
+		ImportData memory data;
+
+		AaveInterface aave = AaveInterface(aaveProvider.getPool());
+
+		data = getBorrowAmounts(userAccount, aave, inputData, data);
+		data = getSupplyAmounts(userAccount, inputData, data);
+
+		//  payback borrowed amount;
+		_PaybackStable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.stableBorrowAmts,
+			userAccount
+		);
+		_PaybackVariable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.variableBorrowAmts,
+			userAccount
+		);
+
+		//  transfer atokens to this address;
+		_TransferAtokensWithCollateral(
+			data._supplyTokens.length,
+			aave,
+			data.aTokens,
+			data.supplyAmts,
+			data._supplyTokens,
+			enableCollateral,
+			userAccount
+		);
+
+		// borrow assets after migrating position
+		if (data.convertStable) {
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.totalBorrowAmtsWithFee
+			);
+		} else {
+			_BorrowStable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.stableBorrowAmtsWithFee
+			);
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.variableBorrowAmtsWithFee
+			);
+		}
+
+		_eventName = "LogAaveV3ImportWithCollateral(address,bool,address[],address[],uint256[],uint256[],uint256[],uint256[],bool[])";
+		_eventParam = abi.encode(
+			userAccount,
+			inputData.convertStable,
+			inputData.supplyTokens,
+			inputData.borrowTokens,
+			inputData.flashLoanFees,
+			data.supplyAmts,
+			data.stableBorrowAmts,
+			data.variableBorrowAmts,
+			enableCollateral
+		);
+	}
+
 	/**
 	 * @dev Import aave V3 position .
 	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
@@ -104,8 +187,23 @@ contract AaveV3ImportResolver is AaveHelpers {
 	{
 		(_eventName, _eventParam) = _importAave(userAccount, inputData);
 	}
+
+	/**
+	 * @dev Import aave V3 position (with collateral).
+	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
+	 * @param userAccount The address of the EOA from which aave position will be imported
+	 * @param inputData The struct containing all the neccessary input data
+	 * @param enableCollateral The boolean array to enable selected collaterals in the imported position
+	 */
+	function importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		external
+		payable
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		(_eventName, _eventParam) = _importAaveWithCollateral(userAccount, inputData, enableCollateral);
+	}
 }
 
 contract ConnectV2AaveV3ImportAvalanche is AaveV3ImportResolver {
-	string public constant name = "Aave-v3-import-v1";
+	string public constant name = "Aave-v3-import-v1.1";
 }

--- a/contracts/fantom/connectors/aave/v3-import/events.sol
+++ b/contracts/fantom/connectors/aave/v3-import/events.sol
@@ -12,4 +12,14 @@ contract Events {
 		uint256[] supplyAmts,
 		uint256[] borrowAmts
 	);
+	event LogAaveV3ImportWithCollateral(
+		address indexed user,
+		address[] ctokens,
+		string[] supplyIds,
+		string[] borrowIds,
+		uint256[] flashLoanFees,
+		uint256[] supplyAmts,
+		uint256[] borrowAmts,
+		bool[] enableCollateral
+	);
 }

--- a/contracts/fantom/connectors/aave/v3-import/helpers.sol
+++ b/contracts/fantom/connectors/aave/v3-import/helpers.sol
@@ -250,6 +250,34 @@ contract AaveHelpers is Helper {
 		}
 	}
 
+	function _TransferAtokensWithCollateral(
+		uint256 _length,
+		AaveInterface aave,
+		ATokenInterface[] memory atokenContracts,
+		uint256[] memory amts,
+		address[] memory tokens,
+		bool[] memory colEnable,
+		address userAccount
+	) internal {
+		for (uint256 i = 0; i < _length; i++) {
+			if (amts[i] > 0) {
+				uint256 _amt = amts[i];
+				require(
+					atokenContracts[i].transferFrom(
+						userAccount,
+						address(this),
+						_amt
+					),
+					"allowance?"
+				);
+
+				if (!getIsColl(tokens[i], address(this))) {
+					aave.setUserUseReserveAsCollateral(tokens[i], colEnable[i]);
+				}
+			}
+		}
+	}
+
 	function _BorrowVariable(
 		uint256 _length,
 		AaveInterface aave,

--- a/contracts/fantom/connectors/aave/v3-import/main.sol
+++ b/contracts/fantom/connectors/aave/v3-import/main.sol
@@ -92,6 +92,89 @@ contract AaveV3ImportResolver is AaveHelpers {
 		);
 	}
 
+	function _importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		internal
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		require(
+			AccountInterface(address(this)).isAuth(userAccount),
+			"user-account-not-auth"
+		);
+
+		require(inputData.supplyTokens.length > 0, "0-length-not-allowed");
+		require(enableCollateral.length == inputData.supplyTokens.length, "lengths-not-same");
+		
+		ImportData memory data;
+
+		AaveInterface aave = AaveInterface(aaveProvider.getPool());
+
+		data = getBorrowAmounts(userAccount, aave, inputData, data);
+		data = getSupplyAmounts(userAccount, inputData, data);
+
+		//  payback borrowed amount;
+		_PaybackStable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.stableBorrowAmts,
+			userAccount
+		);
+		_PaybackVariable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.variableBorrowAmts,
+			userAccount
+		);
+
+		//  transfer atokens to this address;
+		_TransferAtokensWithCollateral(
+			data._supplyTokens.length,
+			aave,
+			data.aTokens,
+			data.supplyAmts,
+			data._supplyTokens,
+			enableCollateral,
+			userAccount
+		);
+
+		// borrow assets after migrating position
+		if (data.convertStable) {
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.totalBorrowAmtsWithFee
+			);
+		} else {
+			_BorrowStable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.stableBorrowAmtsWithFee
+			);
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.variableBorrowAmtsWithFee
+			);
+		}
+
+		_eventName = "LogAaveV3ImportWithCollateral(address,bool,address[],address[],uint256[],uint256[],uint256[],uint256[],bool[])";
+		_eventParam = abi.encode(
+			userAccount,
+			inputData.convertStable,
+			inputData.supplyTokens,
+			inputData.borrowTokens,
+			inputData.flashLoanFees,
+			data.supplyAmts,
+			data.stableBorrowAmts,
+			data.variableBorrowAmts,
+			enableCollateral
+		);
+	}
+
 	/**
 	 * @dev Import aave V3 position .
 	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
@@ -105,8 +188,23 @@ contract AaveV3ImportResolver is AaveHelpers {
 	{
 		(_eventName, _eventParam) = _importAave(userAccount, inputData);
 	}
+
+	/**
+	 * @dev Import aave V3 position (with collateral).
+	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
+	 * @param userAccount The address of the EOA from which aave position will be imported
+	 * @param inputData The struct containing all the neccessary input data
+	 * @param enableCollateral The boolean array to enable selected collaterals in the imported position
+	 */
+	function importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		external
+		payable
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		(_eventName, _eventParam) = _importAaveWithCollateral(userAccount, inputData, enableCollateral);
+	}
 }
 
 contract ConnectV2AaveV3ImportFantom is AaveV3ImportResolver {
-	string public constant name = "Aave-v3-import-v1";
+	string public constant name = "Aave-v3-import-v1.1";
 }

--- a/contracts/mainnet/connectors/aave/v3-import/events.sol
+++ b/contracts/mainnet/connectors/aave/v3-import/events.sol
@@ -12,4 +12,14 @@ contract Events {
 		uint256[] supplyAmts,
 		uint256[] borrowAmts
 	);
+	event LogAaveV3ImportWithCollateral(
+		address indexed user,
+		address[] atokens,
+		string[] supplyIds,
+		string[] borrowIds,
+		uint256[] flashLoanFees,
+		uint256[] supplyAmts,
+		uint256[] borrowAmts,
+		bool[] enableCollateral
+	);
 }

--- a/contracts/mainnet/connectors/aave/v3-import/helpers.sol
+++ b/contracts/mainnet/connectors/aave/v3-import/helpers.sol
@@ -250,6 +250,34 @@ contract AaveHelpers is Helper {
 		}
 	}
 
+	function _TransferAtokensWithCollateral(
+		uint256 _length,
+		AaveInterface aave,
+		ATokenInterface[] memory atokenContracts,
+		uint256[] memory amts,
+		address[] memory tokens,
+		bool[] memory colEnable,
+		address userAccount
+	) internal {
+		for (uint256 i = 0; i < _length; i++) {
+			if (amts[i] > 0) {
+				uint256 _amt = amts[i];
+				require(
+					atokenContracts[i].transferFrom(
+						userAccount,
+						address(this),
+						_amt
+					),
+					"allowance?"
+				);
+
+				if (!getIsColl(tokens[i], address(this))) {
+					aave.setUserUseReserveAsCollateral(tokens[i], colEnable[i]);
+				}
+			}
+		}
+	}
+
 	function _BorrowVariable(
 		uint256 _length,
 		AaveInterface aave,

--- a/contracts/mainnet/connectors/aave/v3-import/main.sol
+++ b/contracts/mainnet/connectors/aave/v3-import/main.sol
@@ -91,6 +91,89 @@ contract AaveV3ImportResolver is AaveHelpers {
 		);
 	}
 
+	function _importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		internal
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		require(
+			AccountInterface(address(this)).isAuth(userAccount),
+			"user-account-not-auth"
+		);
+
+		require(inputData.supplyTokens.length > 0, "0-length-not-allowed");
+		require(enableCollateral.length == inputData.supplyTokens.length, "lengths-not-same");
+
+		ImportData memory data;
+
+		AaveInterface aave = AaveInterface(aaveProvider.getPool());
+
+		data = getBorrowAmounts(userAccount, aave, inputData, data);
+		data = getSupplyAmounts(userAccount, inputData, data);
+
+		//  payback borrowed amount;
+		_PaybackStable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.stableBorrowAmts,
+			userAccount
+		);
+		_PaybackVariable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.variableBorrowAmts,
+			userAccount
+		);
+
+		//  transfer atokens to this address;
+		_TransferAtokensWithCollateral(
+			data._supplyTokens.length,
+			aave,
+			data.aTokens,
+			data.supplyAmts,
+			data._supplyTokens,
+			enableCollateral,
+			userAccount
+		);
+
+		// borrow assets after migrating position
+		if (data.convertStable) {
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.totalBorrowAmtsWithFee
+			);
+		} else {
+			_BorrowStable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.stableBorrowAmtsWithFee
+			);
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.variableBorrowAmtsWithFee
+			);
+		}
+
+		_eventName = "LogAaveV3ImportWithCollateral(address,bool,address[],address[],uint256[],uint256[],uint256[],uint256[],bool[])";
+		_eventParam = abi.encode(
+			userAccount,
+			inputData.convertStable,
+			inputData.supplyTokens,
+			inputData.borrowTokens,
+			inputData.flashLoanFees,
+			data.supplyAmts,
+			data.stableBorrowAmts,
+			data.variableBorrowAmts,
+			enableCollateral
+		);
+	}
+
 	/**
 	 * @dev Import aave V3 position .
 	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
@@ -104,8 +187,23 @@ contract AaveV3ImportResolver is AaveHelpers {
 	{
 		(_eventName, _eventParam) = _importAave(userAccount, inputData);
 	}
+
+	/**
+	 * @dev Import aave V3 position (with collateral).
+	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
+	 * @param userAccount The address of the EOA from which aave position will be imported
+	 * @param inputData The struct containing all the neccessary input data
+	 * @param enableCollateral The boolean array to enable selected collaterals in the imported position
+	 */
+	function importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		external
+		payable
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		(_eventName, _eventParam) = _importAaveWithCollateral(userAccount, inputData, enableCollateral);
+	}
 }
 
 contract ConnectV2AaveV3Import is AaveV3ImportResolver {
-	string public constant name = "Aave-v3-import-v1";
+	string public constant name = "Aave-v3-import-v1.1";
 }

--- a/contracts/optimism/connectors/aave/v3-import/events.sol
+++ b/contracts/optimism/connectors/aave/v3-import/events.sol
@@ -12,4 +12,14 @@ contract Events {
 		uint256[] supplyAmts,
 		uint256[] borrowAmts
 	);
+	event LogAaveV3ImportWithCollateral(
+		address indexed user,
+		address[] ctokens,
+		string[] supplyIds,
+		string[] borrowIds,
+		uint256[] flashLoanFees,
+		uint256[] supplyAmts,
+		uint256[] borrowAmts,
+		bool[] enableCollateral
+	);
 }

--- a/contracts/optimism/connectors/aave/v3-import/helpers.sol
+++ b/contracts/optimism/connectors/aave/v3-import/helpers.sol
@@ -250,6 +250,34 @@ contract AaveHelpers is Helper {
 		}
 	}
 
+	function _TransferAtokensWithCollateral(
+		uint256 _length,
+		AaveInterface aave,
+		ATokenInterface[] memory atokenContracts,
+		uint256[] memory amts,
+		address[] memory tokens,
+		bool[] memory colEnable,
+		address userAccount
+	) internal {
+		for (uint256 i = 0; i < _length; i++) {
+			if (amts[i] > 0) {
+				uint256 _amt = amts[i];
+				require(
+					atokenContracts[i].transferFrom(
+						userAccount,
+						address(this),
+						_amt
+					),
+					"allowance?"
+				);
+
+				if (!getIsColl(tokens[i], address(this))) {
+					aave.setUserUseReserveAsCollateral(tokens[i], colEnable[i]);
+				}
+			}
+		}
+	}
+
 	function _BorrowVariable(
 		uint256 _length,
 		AaveInterface aave,

--- a/contracts/optimism/connectors/aave/v3-import/main.sol
+++ b/contracts/optimism/connectors/aave/v3-import/main.sol
@@ -91,6 +91,89 @@ contract AaveV3ImportResolver is AaveHelpers {
 		);
 	}
 
+	function _importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		internal
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		require(
+			AccountInterface(address(this)).isAuth(userAccount),
+			"user-account-not-auth"
+		);
+
+		require(inputData.supplyTokens.length > 0, "0-length-not-allowed");
+		require(enableCollateral.length == inputData.supplyTokens.length, "lengths-not-same");
+		
+		ImportData memory data;
+
+		AaveInterface aave = AaveInterface(aaveProvider.getPool());
+
+		data = getBorrowAmounts(userAccount, aave, inputData, data);
+		data = getSupplyAmounts(userAccount, inputData, data);
+
+		//  payback borrowed amount;
+		_PaybackStable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.stableBorrowAmts,
+			userAccount
+		);
+		_PaybackVariable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.variableBorrowAmts,
+			userAccount
+		);
+
+		//  transfer atokens to this address;
+		_TransferAtokensWithCollateral(
+			data._supplyTokens.length,
+			aave,
+			data.aTokens,
+			data.supplyAmts,
+			data._supplyTokens,
+			enableCollateral,
+			userAccount
+		);
+
+		// borrow assets after migrating position
+		if (data.convertStable) {
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.totalBorrowAmtsWithFee
+			);
+		} else {
+			_BorrowStable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.stableBorrowAmtsWithFee
+			);
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.variableBorrowAmtsWithFee
+			);
+		}
+
+		_eventName = "LogAaveV3ImportWithCollateral(address,bool,address[],address[],uint256[],uint256[],uint256[],uint256[],bool[])";
+		_eventParam = abi.encode(
+			userAccount,
+			inputData.convertStable,
+			inputData.supplyTokens,
+			inputData.borrowTokens,
+			inputData.flashLoanFees,
+			data.supplyAmts,
+			data.stableBorrowAmts,
+			data.variableBorrowAmts,
+			enableCollateral
+		);
+	}
+
 	/**
 	 * @dev Import aave V3 position .
 	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
@@ -104,8 +187,23 @@ contract AaveV3ImportResolver is AaveHelpers {
 	{
 		(_eventName, _eventParam) = _importAave(userAccount, inputData);
 	}
+
+	/**
+	 * @dev Import aave V3 position (with collateral).
+	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
+	 * @param userAccount The address of the EOA from which aave position will be imported
+	 * @param inputData The struct containing all the neccessary input data
+	 * @param enableCollateral The boolean array to enable selected collaterals in the imported position
+	 */
+	function importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		external
+		payable
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		(_eventName, _eventParam) = _importAaveWithCollateral(userAccount, inputData, enableCollateral);
+	}
 }
 
 contract ConnectV2AaveV3ImportOptimism is AaveV3ImportResolver {
-	string public constant name = "Aave-v3-import-v1";
+	string public constant name = "Aave-v3-import-v1.1";
 }

--- a/contracts/polygon/connectors/aave/v3-import/events.sol
+++ b/contracts/polygon/connectors/aave/v3-import/events.sol
@@ -12,4 +12,14 @@ contract Events {
 		uint256[] supplyAmts,
 		uint256[] borrowAmts
 	);
+	event LogAaveV3ImportWithCollateral(
+		address indexed user,
+		address[] ctokens,
+		string[] supplyIds,
+		string[] borrowIds,
+		uint256[] flashLoanFees,
+		uint256[] supplyAmts,
+		uint256[] borrowAmts,
+		bool[] enableCollateral
+	);
 }

--- a/contracts/polygon/connectors/aave/v3-import/helpers.sol
+++ b/contracts/polygon/connectors/aave/v3-import/helpers.sol
@@ -260,7 +260,7 @@ contract AaveHelpers is Helper {
 		address userAccount
 	) internal {
 		for (uint256 i = 0; i < _length; i++) {
-			if (amts[i] > 0 && colEnable[i]) {
+			if (amts[i] > 0) {
 				uint256 _amt = amts[i];
 				require(
 					atokenContracts[i].transferFrom(
@@ -272,7 +272,7 @@ contract AaveHelpers is Helper {
 				);
 
 				if (!getIsColl(tokens[i], address(this))) {
-					aave.setUserUseReserveAsCollateral(tokens[i], true);
+					aave.setUserUseReserveAsCollateral(tokens[i], colEnable[i]);
 				}
 			}
 		}

--- a/contracts/polygon/connectors/aave/v3-import/helpers.sol
+++ b/contracts/polygon/connectors/aave/v3-import/helpers.sol
@@ -229,10 +229,11 @@ contract AaveHelpers is Helper {
 		ATokenInterface[] memory atokenContracts,
 		uint256[] memory amts,
 		address[] memory tokens,
+		bool[] memory colEnable,
 		address userAccount
 	) internal {
 		for (uint256 i = 0; i < _length; i++) {
-			if (amts[i] > 0) {
+			if (amts[i] > 0 && colEnable[i]) {
 				uint256 _amt = amts[i];
 				require(
 					atokenContracts[i].transferFrom(

--- a/contracts/polygon/connectors/aave/v3-import/helpers.sol
+++ b/contracts/polygon/connectors/aave/v3-import/helpers.sol
@@ -229,6 +229,33 @@ contract AaveHelpers is Helper {
 		ATokenInterface[] memory atokenContracts,
 		uint256[] memory amts,
 		address[] memory tokens,
+		address userAccount
+	) internal {
+		for (uint256 i = 0; i < _length; i++) {
+			if (amts[i] > 0) {
+				uint256 _amt = amts[i];
+				require(
+					atokenContracts[i].transferFrom(
+						userAccount,
+						address(this),
+						_amt
+					),
+					"allowance?"
+				);
+
+				if (!getIsColl(tokens[i], address(this))) {
+					aave.setUserUseReserveAsCollateral(tokens[i], true);
+				}
+			}
+		}
+	}
+
+	function _TransferAtokensWithCollateral(
+		uint256 _length,
+		AaveInterface aave,
+		ATokenInterface[] memory atokenContracts,
+		uint256[] memory amts,
+		address[] memory tokens,
 		bool[] memory colEnable,
 		address userAccount
 	) internal {

--- a/contracts/polygon/connectors/aave/v3-import/main.sol
+++ b/contracts/polygon/connectors/aave/v3-import/main.sol
@@ -127,12 +127,13 @@ contract AaveV3ImportResolver is AaveHelpers {
 		);
 
 		//  transfer atokens to this address;
-		_TransferAtokens(
+		_TransferAtokensWithCollateral(
 			data._supplyTokens.length,
 			aave,
 			data.aTokens,
 			data.supplyAmts,
 			data._supplyTokens,
+			enableCollateral,
 			userAccount
 		);
 

--- a/contracts/polygon/connectors/aave/v3-import/main.sol
+++ b/contracts/polygon/connectors/aave/v3-import/main.sol
@@ -102,6 +102,7 @@ contract AaveV3ImportResolver is AaveHelpers {
 		);
 
 		require(inputData.supplyTokens.length > 0, "0-length-not-allowed");
+		require(enableCollateral.length == inputData.supplyTokens.length, "lengths-not-same");
 
 		ImportData memory data;
 
@@ -205,5 +206,5 @@ contract AaveV3ImportResolver is AaveHelpers {
 }
 
 contract ConnectV2AaveV3ImportPolygon is AaveV3ImportResolver {
-	string public constant name = "Aave-v3-import-v1";
+	string public constant name = "Aave-v3-import-v1.1";
 }

--- a/contracts/polygon/connectors/aave/v3-import/main.sol
+++ b/contracts/polygon/connectors/aave/v3-import/main.sol
@@ -160,7 +160,7 @@ contract AaveV3ImportResolver is AaveHelpers {
 			);
 		}
 
-		_eventName = "LogAaveV3ImportWithCollateral(address,bool,address[],address[],uint256[],uint256[],uint256[],uint256[])";
+		_eventName = "LogAaveV3ImportWithCollateral(address,bool,address[],address[],uint256[],uint256[],uint256[],uint256[],bool[])";
 		_eventParam = abi.encode(
 			userAccount,
 			inputData.convertStable,

--- a/contracts/polygon/connectors/aave/v3-import/main.sol
+++ b/contracts/polygon/connectors/aave/v3-import/main.sol
@@ -92,6 +92,87 @@ contract AaveV3ImportResolver is AaveHelpers {
 		);
 	}
 
+	function _importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		internal
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		require(
+			AccountInterface(address(this)).isAuth(userAccount),
+			"user-account-not-auth"
+		);
+
+		require(inputData.supplyTokens.length > 0, "0-length-not-allowed");
+
+		ImportData memory data;
+
+		AaveInterface aave = AaveInterface(aaveProvider.getPool());
+
+		data = getBorrowAmounts(userAccount, aave, inputData, data);
+		data = getSupplyAmounts(userAccount, inputData, data);
+
+		//  payback borrowed amount;
+		_PaybackStable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.stableBorrowAmts,
+			userAccount
+		);
+		_PaybackVariable(
+			data._borrowTokens.length,
+			aave,
+			data._borrowTokens,
+			data.variableBorrowAmts,
+			userAccount
+		);
+
+		//  transfer atokens to this address;
+		_TransferAtokens(
+			data._supplyTokens.length,
+			aave,
+			data.aTokens,
+			data.supplyAmts,
+			data._supplyTokens,
+			userAccount
+		);
+
+		// borrow assets after migrating position
+		if (data.convertStable) {
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.totalBorrowAmtsWithFee
+			);
+		} else {
+			_BorrowStable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.stableBorrowAmtsWithFee
+			);
+			_BorrowVariable(
+				data._borrowTokens.length,
+				aave,
+				data._borrowTokens,
+				data.variableBorrowAmtsWithFee
+			);
+		}
+
+		_eventName = "LogAaveV3ImportWithCollateral(address,bool,address[],address[],uint256[],uint256[],uint256[],uint256[])";
+		_eventParam = abi.encode(
+			userAccount,
+			inputData.convertStable,
+			inputData.supplyTokens,
+			inputData.borrowTokens,
+			inputData.flashLoanFees,
+			data.supplyAmts,
+			data.stableBorrowAmts,
+			data.variableBorrowAmts,
+			enableCollateral
+		);
+	}
+
 	/**
 	 * @dev Import aave V3 position .
 	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
@@ -104,6 +185,21 @@ contract AaveV3ImportResolver is AaveHelpers {
 		returns (string memory _eventName, bytes memory _eventParam)
 	{
 		(_eventName, _eventParam) = _importAave(userAccount, inputData);
+	}
+
+	/**
+	 * @dev Import aave V3 position (with collateral).
+	 * @notice Import EOA's aave V3 position to DSA's aave v3 position
+	 * @param userAccount The address of the EOA from which aave position will be imported
+	 * @param inputData The struct containing all the neccessary input data
+	 * @param enableCollateral The boolean array to enable selected collaterals in the imported position
+	 */
+	function importAaveWithCollateral(address userAccount, ImportInputData memory inputData, bool[] memory enableCollateral)
+		external
+		payable
+		returns (string memory _eventName, bytes memory _eventParam)
+	{
+		(_eventName, _eventParam) = _importAaveWithCollateral(userAccount, inputData, enableCollateral);
 	}
 }
 


### PR DESCRIPTION
Aave V3 import with Collateral. 
- Function `importAaveWithCollateral` takes array of bools `enableCollateral` as param.
- Will enable only selected tokens as collateral while importing the position.
- [x] Implementation
- [x] Deployment
- [x] Add to SDK https://github.com/Instadapp/dsa-connect/pull/168
- [x] Enable
- [ ] Update docs