### PR TITLE
ci: harden PR status checks (pull_request_target -> pull_request)

### DIFF
--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -1,7 +1,7 @@
 name: PR status checks
 on:
-  pull_request_target:
-    types: [assigned, opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
@@ -13,8 +13,6 @@ jobs:
         node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
`status.yml` used `pull_request_target` + checkout of the PR head + `npm install`/`ts-node`.
Switching to `pull_request` removes the privileged context (cache poisoning / untrusted
code execution). It also aligns with comment-pr.yml's `workflow_run.event == 'pull_request'`
condition, which never matched while the upstream ran as pull_request_target.